### PR TITLE
Continue to use current access token while refreshing in background

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tesseral/tesseral-react",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/src/default-mode-access-token-provider.tsx
+++ b/src/default-mode-access-token-provider.tsx
@@ -63,7 +63,5 @@ function useAccessToken(): string | undefined {
     throw error;
   }
 
-  if (accessTokenLikelyValid) {
-    return accessToken!;
-  }
+  return accessToken;
 }

--- a/src/dev-mode-access-token-provider.tsx
+++ b/src/dev-mode-access-token-provider.tsx
@@ -158,9 +158,7 @@ function useAccessToken(): string | undefined {
     throw error;
   }
 
-  if (accessTokenLikelyValid) {
-    return accessToken!;
-  }
+  return accessToken ?? undefined;
 }
 
 async function handleRelayedSession({


### PR DESCRIPTION
This PR has `TesseralProvider` return the current access token to its downstream consumers even as a new one is being fetched.