### PR TITLE
[OPEN-362] Hold access tokens in memory after refresh

### DIFF
--- a/src/default-mode-access-token-provider.tsx
+++ b/src/default-mode-access-token-provider.tsx
@@ -33,7 +33,9 @@ function useAccessToken(): string | undefined {
   const projectId = useProjectId();
   const vaultDomain = useVaultDomain();
   const frontendApiClient = useFrontendApiClientInternal();
-  const [accessToken, setAccessToken] = useState<string | undefined>(getCookie(`tesseral_${projectId}_access_token`));
+  const [accessToken, setAccessToken] = useState<string | undefined>(() => {
+    return getCookie(`tesseral_${projectId}_access_token`);
+  });
 
   const [error, setError] = useState<unknown>();
   const accessTokenLikelyValid = useAccessTokenLikelyValid(accessToken ?? "");

--- a/src/default-mode-access-token-provider.tsx
+++ b/src/default-mode-access-token-provider.tsx
@@ -33,9 +33,9 @@ function useAccessToken(): string | undefined {
   const projectId = useProjectId();
   const vaultDomain = useVaultDomain();
   const frontendApiClient = useFrontendApiClientInternal();
+  const [accessToken, setAccessToken] = useState<string | undefined>(getCookie(`tesseral_${projectId}_access_token`));
 
   const [error, setError] = useState<unknown>();
-  const accessToken = getCookie(`tesseral_${projectId}_access_token`);
   const accessTokenLikelyValid = useAccessTokenLikelyValid(accessToken ?? "");
 
   // whenever the access token is invalid or near-expired, refresh it
@@ -46,7 +46,8 @@ function useAccessToken(): string | undefined {
 
     (async () => {
       try {
-        await frontendApiClient.refresh({});
+        const { accessToken } = await frontendApiClient.refresh({});
+        setAccessToken(accessToken);
       } catch (e) {
         if (e instanceof TesseralError && e.statusCode === 401) {
           // our refresh token is no good


### PR DESCRIPTION
This PR fixes issues with unexpected logout states caused by the unreliability of propagation of `document.cookie` updates within a hook.

We still rely on `document.cookie` for initial load, but we hold the `accessToken` returned from the `refresh` call in memory in order to prevent false negatives from outdated `document.cookie` values.

This has been tested in a production app.