### PR TITLE
Resolve electron host issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tesseral/tesseral-react",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/src/publishable-key-config.tsx
+++ b/src/publishable-key-config.tsx
@@ -52,7 +52,7 @@ export function PublishableKeyConfigProvider({
       return;
     }
 
-    if (!publishableKeyConfig.trustedDomains.includes(location.host)) {
+    if (location.host !== "" && !publishableKeyConfig.trustedDomains.includes(location.host)) {
       setError(
         new Error(
           `Tesseral Project ${publishableKeyConfig.projectId} is not configured to be served from ${location.host}. Only the following domains are allowed:\n\n${publishableKeyConfig.trustedDomains.join("\n")}\n\nGo to https://console.tesseral.com/project-settings and add ${location.host} to your list of trusted domains.`,


### PR DESCRIPTION
This PR updates our pre-CORS check against `location.host` to ignore empty strings. Since Electron apps run in an context without a proper host, this check throws false positives.

Instead, we now only throw this error if host is not an empty string **and** the trusted domain check fails.