### PR TITLE
Append /api to constructed instances of TesseralClient

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tesseral/tesseral-react",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/src/dev-mode-access-token-provider.tsx
+++ b/src/dev-mode-access-token-provider.tsx
@@ -39,7 +39,7 @@ function useDevModeFrontendApiClient(accessToken: string) {
 
   return useMemo(() => {
     return new TesseralClient({
-      environment: `https://${vaultDomain}`,
+      environment: `https://${vaultDomain}/api`,
       fetcher: (options) => {
         return fetcher({
           ...options,

--- a/src/use-frontend-api-client-internal.ts
+++ b/src/use-frontend-api-client-internal.ts
@@ -8,7 +8,7 @@ export function useFrontendApiClientInternal() {
 
   return useMemo(() => {
     return new TesseralClient({
-      environment: `https://${vaultDomain}`,
+      environment: `https://${vaultDomain}/api`,
     });
   }, [vaultDomain]);
 }


### PR DESCRIPTION
A previous release of the low-level vanilla JS SDK automatically included an `/api` segment in API route paths, but it is now a responsibility of vanilla-clientside-js callers to include such a path segment.