### PR TITLE
Consolidate `parseAccessToken` usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tesseral/tesseral-react",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tesseral/tesseral-react",
-      "version": "0.0.22",
+      "version": "0.0.23",
       "dependencies": {
         "@tesseral/tesseral-vanilla-clientside": "^0.0.8"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tesseral/tesseral-react",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/src/access-token-likely-valid.ts
+++ b/src/access-token-likely-valid.ts
@@ -1,6 +1,6 @@
-import { parseAccessToken } from "parse-access-token";
 import { useMemo } from "react";
 
+import { parseAccessToken } from "./parse-access-token";
 import { useDebouncedNow } from "./use-debounced-now";
 
 const ACCESS_TOKEN_EXPIRY_BUFFER_MILLIS = 10 * 1000;


### PR DESCRIPTION
Follow up to #11 to use the new `parseAccessToken` method everywhere.