### PR TITLE
Suspend on expired access tokens

### DIFF
--- a/src/access-token-likely-valid.ts
+++ b/src/access-token-likely-valid.ts
@@ -5,13 +5,35 @@ import { useDebouncedNow } from "./use-debounced-now";
 
 const ACCESS_TOKEN_EXPIRY_BUFFER_MILLIS = 10 * 1000;
 
+/**
+ * Returns true if the access token is well-formed and expires far enough in
+ * the future.
+ *
+ * @param accessToken
+ */
 export function useAccessTokenLikelyValid(accessToken: string): boolean {
-  const now = useDebouncedNow(10 * 1000); // re-check expiration every 10 seconds
+  const now = useDebouncedNow(2 * 1000); // re-check expiration every 2 seconds
   return useMemo(() => {
     if (!accessToken) {
       return false;
     }
     const parsedAccessToken = parseAccessToken(accessToken);
     return parsedAccessToken.exp! * 1000 > now + ACCESS_TOKEN_EXPIRY_BUFFER_MILLIS;
+  }, [accessToken, now]);
+}
+
+/**
+ * Returns true if the access token is ill-formed or has expired.
+ *
+ * @param accessToken
+ */
+export function useAccessTokenLikelyExpired(accessToken: string): boolean {
+  const now = useDebouncedNow(2 * 1000); // re-check expiration every 2 seconds
+  return useMemo(() => {
+    if (!accessToken) {
+      return false;
+    }
+    const parsedAccessToken = parseAccessToken(accessToken);
+    return parsedAccessToken.exp! * 1000 < now;
   }, [accessToken, now]);
 }

--- a/src/default-mode-access-token-provider.tsx
+++ b/src/default-mode-access-token-provider.tsx
@@ -1,7 +1,7 @@
 import { TesseralError } from "@tesseral/tesseral-vanilla-clientside";
 import React, { useEffect, useMemo, useState } from "react";
 
-import { useAccessTokenLikelyValid } from "./access-token-likely-valid";
+import { useAccessTokenLikelyExpired, useAccessTokenLikelyValid } from "./access-token-likely-valid";
 import { getCookie } from "./cookie";
 import { InternalAccessTokenContext, InternalAccessTokenContextValue } from "./internal-access-token-context";
 import { useProjectId, useVaultDomain } from "./publishable-key-config";
@@ -39,6 +39,7 @@ function useAccessToken(): string | undefined {
 
   const [error, setError] = useState<unknown>();
   const accessTokenLikelyValid = useAccessTokenLikelyValid(accessToken ?? "");
+  const accessTokenLikelyExpired = useAccessTokenLikelyExpired(accessToken ?? "");
 
   // whenever the access token is invalid or near-expired, refresh it
   useEffect(() => {
@@ -66,5 +67,9 @@ function useAccessToken(): string | undefined {
     throw error;
   }
 
+  // if the access token is likely expired, don't return it; wait for refresh
+  if (accessTokenLikelyExpired) {
+    return;
+  }
   return accessToken;
 }

--- a/src/dev-mode-access-token-provider.tsx
+++ b/src/dev-mode-access-token-provider.tsx
@@ -2,7 +2,7 @@ import { TesseralClient, TesseralError } from "@tesseral/tesseral-vanilla-client
 import { fetcher } from "@tesseral/tesseral-vanilla-clientside/core";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 
-import { useAccessTokenLikelyValid } from "./access-token-likely-valid";
+import { useAccessTokenLikelyExpired, useAccessTokenLikelyValid } from "./access-token-likely-valid";
 import { setCookie } from "./cookie";
 import { InternalAccessTokenContext, InternalAccessTokenContextValue } from "./internal-access-token-context";
 import { useProjectId, useVaultDomain } from "./publishable-key-config";
@@ -70,6 +70,7 @@ function useAccessToken(): string | undefined {
   const strictModeDedupeRelayedSession = useRef(false);
 
   const accessTokenLikelyValid = useAccessTokenLikelyValid(accessToken ?? "");
+  const accessTokenLikelyExpired = useAccessTokenLikelyExpired(accessToken ?? "");
 
   const [error, setError] = useState<unknown>();
 
@@ -158,6 +159,10 @@ function useAccessToken(): string | undefined {
     throw error;
   }
 
+  // if the access token is likely expired, don't return it; wait for refresh
+  if (accessTokenLikelyExpired) {
+    return;
+  }
   return accessToken ?? undefined;
 }
 


### PR DESCRIPTION
In the case where a user has a working refresh token, and visits a TesseralProvider-protected page with an expired access token, TesseralProvider today optimistically renders with that expired access token, and immediately begins refreshing it.

This PR changes that behavior. Expired access tokens cause a suspended state. The logic for triggering pre-refreshing is unchanged.

This change is to reduce a class of errors for users, where the expired access tokens make fetches that fail. It's very common for that to have negative effects in terms of faulty redirects or other irrecoverable error states on the frontend. It also causes noise in bugsnaggers.

In service of making the pre-refreshing more accurate, this PR also updates the checking period for these to 2 seconds. This PR makes our behavior change in the 10-second window at the end of an access token's lifetime. This has a sort of Nyquist rate effect, and making the (inexpensive) expiry checks happen at least twice as often as the 10-second period makes this code more obviously correct.