### PR TITLE
Redirect to current href post-login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tesseral/tesseral-react",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tesseral/tesseral-react",
-      "version": "0.0.24",
+      "version": "0.0.25",
       "dependencies": {
         "@tesseral/tesseral-vanilla-clientside": "^0.0.8"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tesseral/tesseral-react",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "",
   "main": "dist/index.js",
   "files": [
@@ -14,7 +14,7 @@
     "build": "rm -rf dist && tsc",
     "dev": "npm-run-all -p dev:*",
     "dev:esbuild": "cd src/test-app && esbuild --bundle --outfile=public/index.js ./src --watch",
-    "dev:serve": "cd src/test-app && serve public -l 4000",
+    "dev:serve": "cd src/test-app && serve public -s -l 4000",
     "test": "jest"
   },
   "repository": {

--- a/src/default-mode-access-token-provider.tsx
+++ b/src/default-mode-access-token-provider.tsx
@@ -54,7 +54,9 @@ function useAccessToken(): string | undefined {
       } catch (e) {
         if (e instanceof TesseralError && e.statusCode === 401) {
           // our refresh token is no good
-          window.location.href = `https://${vaultDomain}/login`;
+          const loginUrl = new URL(`https://${vaultDomain}/login`);
+          loginUrl.searchParams.set("redirect-uri", window.location.href);
+          window.location.href = loginUrl.toString();
           return;
         }
 

--- a/src/dev-mode-access-token-provider.tsx
+++ b/src/dev-mode-access-token-provider.tsx
@@ -238,5 +238,10 @@ async function exchangeRelayedSessionToken({
 async function redirectToVaultLogin({ projectId, vaultDomain }: { projectId: string; vaultDomain: string }) {
   const relayedSessionState = crypto.randomUUID();
   localStorage.setItem(`tesseral_${projectId}_relayed_session_state`, await sha256(relayedSessionState));
-  window.location.href = `https://${vaultDomain}/login?relayed-session-state=${relayedSessionState}`;
+
+  const loginUrl = new URL(`https://${vaultDomain}/login`);
+  loginUrl.searchParams.set("relayed-session-state", relayedSessionState);
+  loginUrl.searchParams.set("redirect-uri", window.location.href);
+
+  window.location.href = loginUrl.toString();
 }


### PR DESCRIPTION
When redirecting to the vault login, we should pass along the current URL so that the vault can redirect back to the correct page after login.